### PR TITLE
Fix shield tooltip formatting

### DIFF
--- a/src/main/java/gmail/Lance5057/items/HeaterShield.java
+++ b/src/main/java/gmail/Lance5057/items/HeaterShield.java
@@ -220,18 +220,18 @@ public class HeaterShield extends HarvestTool implements IShield, ISheathed, IAr
         super.addInformation(par1ItemStack, par2EntityPlayer, par3List, par4);
         par3List.add("");
         par3List.add(
-                EnumChatFormatting.DARK_GREEN
-                        + ItemStack.field_111284_a.format(
-                                1F / (10f / (tags.getCompoundTag("InfiTool").getInteger("MiningSpeed") / 1.5f)) / 20F)
-                        + StatCollector.translateToLocal("attribute.shield.block.time"));
+            EnumChatFormatting.DARK_GREEN
+                + String.format(
+                    StatCollector.translateToLocal("attribute.shield.block.time"),
+                    ItemStack.field_111284_a.format(
+                        1F / (10f / (tags.getCompoundTag("InfiTool").getInteger("MiningSpeed") / 1.5f)) / 20F)));
         int arrowCount = getArrowCount(par1ItemStack);
         if (arrowCount > 0) {
             par3List.add(
-                    String.format(
-                            "%s%s %s",
-                            EnumChatFormatting.GOLD,
-                            arrowCount,
-                            StatCollector.translateToLocal("attribute.shield.arrow.count")));
+                EnumChatFormatting.GOLD
+                    + String.format(
+                        StatCollector.translateToLocal("attribute.shield.arrow.count"),
+                        arrowCount));
         }
     }
 

--- a/src/main/java/gmail/Lance5057/items/HeaterShield.java
+++ b/src/main/java/gmail/Lance5057/items/HeaterShield.java
@@ -220,18 +220,16 @@ public class HeaterShield extends HarvestTool implements IShield, ISheathed, IAr
         super.addInformation(par1ItemStack, par2EntityPlayer, par3List, par4);
         par3List.add("");
         par3List.add(
-            EnumChatFormatting.DARK_GREEN
-                + String.format(
-                    StatCollector.translateToLocal("attribute.shield.block.time"),
-                    ItemStack.field_111284_a.format(
-                        1F / (10f / (tags.getCompoundTag("InfiTool").getInteger("MiningSpeed") / 1.5f)) / 20F)));
+                EnumChatFormatting.DARK_GREEN + StatCollector.translateToLocalFormatted(
+                        "attribute.shield.block.time",
+                        ItemStack.field_111284_a.format(
+                                1F / (10f / (tags.getCompoundTag("InfiTool").getInteger("MiningSpeed") / 1.5f))
+                                        / 20F)));
         int arrowCount = getArrowCount(par1ItemStack);
         if (arrowCount > 0) {
             par3List.add(
-                EnumChatFormatting.GOLD
-                    + String.format(
-                        StatCollector.translateToLocal("attribute.shield.arrow.count"),
-                        arrowCount));
+                    EnumChatFormatting.GOLD
+                            + StatCollector.translateToLocalFormatted("attribute.shield.arrow.count", arrowCount));
         }
     }
 

--- a/src/main/java/gmail/Lance5057/items/RoundShield.java
+++ b/src/main/java/gmail/Lance5057/items/RoundShield.java
@@ -217,8 +217,7 @@ public class RoundShield extends HarvestTool implements IShield, ISheathed, IArr
                 + String.format(
                     StatCollector.translateToLocal("attribute.shield.block.time"),
                     ItemStack.field_111284_a.format(
-                        1F / (10f / tags.getCompoundTag("InfiTool").getInteger("MiningSpeed") * 2) / 20F)
-                ));
+                        1F / (10f / tags.getCompoundTag("InfiTool").getInteger("MiningSpeed") * 2) / 20F)));
         int arrowCount = getArrowCount(par1ItemStack);
         if (arrowCount > 0) {
             par3List.add(

--- a/src/main/java/gmail/Lance5057/items/RoundShield.java
+++ b/src/main/java/gmail/Lance5057/items/RoundShield.java
@@ -213,18 +213,19 @@ public class RoundShield extends HarvestTool implements IShield, ISheathed, IArr
         super.addInformation(par1ItemStack, par2EntityPlayer, par3List, par4);
         par3List.add("");
         par3List.add(
-                EnumChatFormatting.DARK_GREEN
-                        + ItemStack.field_111284_a.format(
-                                1F / (10f / tags.getCompoundTag("InfiTool").getInteger("MiningSpeed") * 2) / 20F)
-                        + StatCollector.translateToLocal("attribute.shield.block.time"));
+            EnumChatFormatting.DARK_GREEN
+                + String.format(
+                    StatCollector.translateToLocal("attribute.shield.block.time"),
+                    ItemStack.field_111284_a.format(
+                        1F / (10f / tags.getCompoundTag("InfiTool").getInteger("MiningSpeed") * 2) / 20F)
+                ));
         int arrowCount = getArrowCount(par1ItemStack);
         if (arrowCount > 0) {
             par3List.add(
-                    String.format(
-                            "%s%s %s",
-                            EnumChatFormatting.GOLD,
-                            arrowCount,
-                            StatCollector.translateToLocal("attribute.shield.arrow.count")));
+                EnumChatFormatting.GOLD
+                    + String.format(
+                        StatCollector.translateToLocal("attribute.shield.arrow.count"),
+                        arrowCount));
         }
     }
 

--- a/src/main/java/gmail/Lance5057/items/RoundShield.java
+++ b/src/main/java/gmail/Lance5057/items/RoundShield.java
@@ -213,18 +213,15 @@ public class RoundShield extends HarvestTool implements IShield, ISheathed, IArr
         super.addInformation(par1ItemStack, par2EntityPlayer, par3List, par4);
         par3List.add("");
         par3List.add(
-            EnumChatFormatting.DARK_GREEN
-                + String.format(
-                    StatCollector.translateToLocal("attribute.shield.block.time"),
-                    ItemStack.field_111284_a.format(
-                        1F / (10f / tags.getCompoundTag("InfiTool").getInteger("MiningSpeed") * 2) / 20F)));
+                EnumChatFormatting.DARK_GREEN + StatCollector.translateToLocalFormatted(
+                        "attribute.shield.block.time",
+                        ItemStack.field_111284_a.format(
+                                1F / (10f / tags.getCompoundTag("InfiTool").getInteger("MiningSpeed") * 2) / 20F)));
         int arrowCount = getArrowCount(par1ItemStack);
         if (arrowCount > 0) {
             par3List.add(
-                EnumChatFormatting.GOLD
-                    + String.format(
-                        StatCollector.translateToLocal("attribute.shield.arrow.count"),
-                        arrowCount));
+                    EnumChatFormatting.GOLD
+                            + StatCollector.translateToLocalFormatted("attribute.shield.arrow.count", arrowCount));
         }
     }
 


### PR DESCRIPTION
Description:  
• Fixes incorrect string concatenation in shield tooltips.  
• Uses `String.format()` for `attribute.shield.block.time` and `attribute.shield.arrow.count` to properly replace `%s` placeholders.  
• Affected files: `HeaterShield.java`, `RoundShield.java`.  

Why:  
This was a bug where translated strings with `%s` would break due to direct value concatenation. The fix ensures values are injected correctly into translations.  